### PR TITLE
Fix keyboard focus for maintainer profile

### DIFF
--- a/components/MaintainerCard.vue
+++ b/components/MaintainerCard.vue
@@ -2,21 +2,24 @@
 defineProps(["maintainer"]);
 </script>
 <template>
-  <div class="flex flex-col border outline-0">
-    <div class="p-8 flex gap-4 items-center bg-tertiary-light dark:bg-tertiary-dark">
+  <div
+    class="flex flex-col border outline-0 hover:outline-1 hover:cursor-pointer focus:outline-1"
+    tabindex="0"
+    role="button"
+    @click="$router.push(maintainer.path)"
+    @keydown.enter="$router.push(maintainer.path)"
+    @keydown.space.prevent="$router.push(maintainer.path)"
+  >
+    <div
+      class="p-8 flex gap-4 items-center bg-tertiary-light dark:bg-tertiary-dark"
+    >
       <MaintainerImage :maintainer="maintainer" />
-      <div class="flex flex-col grow">
+      <div class="flex flex-col">
         <h4 class="font-bold">{{ maintainer.full_name }}</h4>
         <p class="text-sm">
           {{ maintainer.designation }}
         </p>
       </div>
-      <a
-        class="btn-solid text-sm"
-        :href="maintainer.path"
-      >
-        <span>Profile</span>
-      </a>
     </div>
     <div
       class="grid grid-cols-1"

--- a/components/MaintainerCard.vue
+++ b/components/MaintainerCard.vue
@@ -2,20 +2,21 @@
 defineProps(["maintainer"]);
 </script>
 <template>
-  <div
-    class="flex flex-col border outline-0 hover:outline-1 hover:cursor-pointer"
-    @click="$router.push(maintainer.path)"
-  >
-    <div
-      class="p-8 flex gap-4 items-center bg-tertiary-light dark:bg-tertiary-dark"
-    >
+  <div class="flex flex-col border outline-0">
+    <div class="p-8 flex gap-4 items-center bg-tertiary-light dark:bg-tertiary-dark">
       <MaintainerImage :maintainer="maintainer" />
-      <div class="flex flex-col">
+      <div class="flex flex-col grow">
         <h4 class="font-bold">{{ maintainer.full_name }}</h4>
         <p class="text-sm">
           {{ maintainer.designation }}
         </p>
       </div>
+      <a
+        class="btn-solid text-sm"
+        :href="maintainer.path"
+      >
+        <span>Profile</span>
+      </a>
     </div>
     <div
       class="grid grid-cols-1"

--- a/components/ProjectCard.vue
+++ b/components/ProjectCard.vue
@@ -9,6 +9,7 @@ defineProps(["project"]);
       <div class="flex flex-col gap-3">
         <h5 class="font-semibold">{{ project.name }}</h5>
         <a
+          @click.stop
           class="btn-subtle text-sm"
           :href="project.project_link"
           target="_blank"

--- a/components/ProjectCard.vue
+++ b/components/ProjectCard.vue
@@ -9,12 +9,11 @@ defineProps(["project"]);
       <div class="flex flex-col gap-3">
         <h5 class="font-semibold">{{ project.name }}</h5>
         <a
-          @click.stop
           class="btn-subtle text-sm"
           :href="project.project_link"
           target="_blank"
         >
-          <span>View Repository</span>
+          <span>View Source</span>
           <IconsArrowUpRight class="w-5 h-5"></IconsArrowUpRight>
         </a>
       </div>


### PR DESCRIPTION
fixes #43

added the dedicated button for viewing maintainer profile as earlier a click listener was added to the parent `div` which doesn't hold keyboard focus.