### PR TITLE
fix: update profile image

### DIFF
--- a/content/maintainers/raisedadead.json
+++ b/content/maintainers/raisedadead.json
@@ -1,7 +1,7 @@
 {
   "username": "raisedadead",
   "full_name": "Mrugesh Mohapatra",
-  "photo": "https://avatars.githubusercontent.com/u/61445214?s=200&v=4",
+  "photo": "https://avatars.githubusercontent.com/u/1884376?s=200&v=4",
   "designation": "Principal Maintainer—Cloud Infrastructure & Open Source at freeCodeCamp.org",
   "socials": [
     {


### PR DESCRIPTION
Noticed the the image URL was showing up the FOSS United logo. This should fix it.