### PR TITLE
Hide the RSS button

### DIFF
--- a/components/Footer.vue
+++ b/components/Footer.vue
@@ -23,14 +23,14 @@
           Contribute
         </a>
 
-        <a
+        <!--<a
           class="flex text-sm gap-2 items-center btn-subtle w-fit"
           href="https://forklore.in/rss"
           target="_blank"
         >
           <IconsRSS class="w-5 h-5" />
           RSS
-        </a>
+        </a>-->
 
         <a href="mailto:foundation@fossunited.org" class="link flex gap-2">
           <IconsEmailIcon class="w-5 h-5" />


### PR DESCRIPTION
Introduced in #65 , RSS isn't working as expected. @nammahari reported that it was working locally but it's throwing a 500 at the moment - visit forklore.in/rss - so we're just hiding the button for now instead of reverting PR #65 