### PR TITLE
feat: add maintainers forum/discussion to forklore page

### DIFF
--- a/components/Footer.vue
+++ b/components/Footer.vue
@@ -14,7 +14,7 @@
             FOSS United
           </a>
         </p>
-        <div class="flex flex-row gap-4">
+        <div class="flex flex-col sm:flex-row gap-4">
           <a
             class="flex text-sm gap-2 items-center btn-subtle w-fit"
             href="https://github.com/fossunited/forklore"

--- a/components/Footer.vue
+++ b/components/Footer.vue
@@ -26,6 +26,15 @@
 
           <a
             class="flex text-sm gap-2 items-center btn-subtle w-fit"
+            href="https://forum.fossunited.org/c/maintainers/"
+            target="_blank"
+          >
+            <IconsDiscourse class="w-5 h-5" />
+            Forum
+          </a>
+
+          <a
+            class="flex text-sm gap-2 items-center btn-subtle w-fit"
             href="https://forklore.in/rss"
             target="_blank"
           >

--- a/components/HeaderLinks.vue
+++ b/components/HeaderLinks.vue
@@ -8,11 +8,15 @@ const navbarItems = [
     label: "FOSS United Grants",
     href: "https://fossunited.org/grants",
   },
+  {
+    label: "Discussion Forum",
+    href: "https://forum.fossunited.org/c/maintainers/",
+  },
 ];
 </script>
 <template>
-  <ol class="flex flex-col items-end md:flex-row">
-    <li class="py-2 px-4" v-for="item in navbarItems" :key="item.label">
+  <ol class="flex flex-col items-end md:flex-row text-sm">
+    <li class="py-2 px-3" v-for="item in navbarItems" :key="item.label">
       <a :href="item.href">
         {{ item.label }}
       </a>

--- a/components/icons/Discourse.vue
+++ b/components/icons/Discourse.vue
@@ -1,0 +1,18 @@
+<template>
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+  class="icon icon-tabler icon-tabler-brand-discourse"
+>
+  <path stroke="none" d="M0 0h24v24H0z" fill="none" />
+  <path d="M4 12a8 8 0 1 1 16 0c0 4.418 -3.582 8 -8 8h-2l-3 3l1 -3h-1a8 8 0 0 1 -3 -8z" />
+  <circle cx="12" cy="12" r="3" />
+</svg>
+</template>


### PR DESCRIPTION
- We've an maintainers category @ https://forum.fossunited.org/c/maintainers/

This PR links that page in header (navbar) and Footer of the page

- Also added discourse svg icon (not official nor tablet, had to hack on it) to appear for footer

Navbar:

<img width="800" height="500" alt="image" src="https://github.com/user-attachments/assets/0ca383d9-01b0-45d8-9dac-1db2e256d86c" />

Footer:

<img width="800" height="200" alt="image" src="https://github.com/user-attachments/assets/cbaca098-1126-4592-81ba-0795fe460fb7" />
