### PR TITLE
Theme persistence bug resolved

### DIFF
--- a/components/Header.vue
+++ b/components/Header.vue
@@ -25,8 +25,6 @@ const getButtonIcon = () => {
 };
 
 const toggleColorMode = () => {
-  colorMode.forced = true;
-
   if (colorMode.value === "dark") {
     colorMode.preference = "light";
     colorMode.value = "light";


### PR DESCRIPTION
Issue

This PR fixes a bug in Forklore where the selected theme was not persisting across sessions.
Example: The UI component reverted to the default theme regardless of user preference.

Root Cause

The issue was caused by the use of colorMode.forced, which forcefully applied the default theme instead of allowing the chosen theme to persist.

Fix Implemented

Removed colorMode.forced to enable proper theme persistence and ensure that the user’s selected theme remains consistent across sessions.

Testing Done

=> Verified the fix locally.

=> Tested across multiple theme selections and reload scenarios.

=> Confirmed that no other UI components were affected.
Before:
<img width="1920" height="1200" alt="Screenshot (452)" src="https://github.com/user-attachments/assets/1a4e1172-eed8-40af-85ea-8c2e05faa43d" />

After:
<img width="1920" height="1200" alt="Screenshot (450)" src="https://github.com/user-attachments/assets/58f1a3e9-8cb2-409a-815b-a3ec80b49d9f" />
