### PR TITLE
add scroll back to top component

### DIFF
--- a/app.vue
+++ b/app.vue
@@ -1,5 +1,6 @@
 <script lang="ts" setup>
 import BaseLayout from "@/layout/BaseLayout.vue";
+import scrollTop from '@/components/scrollTop.vue'
 
 useHead({
   title: "Forklore",
@@ -27,6 +28,7 @@ useSeoMeta({
 </script>
 <template>
   <BaseLayout>
-    <NuxtPage> </NuxtPage>
+      <NuxtPage />
+      <scrollTop />
   </BaseLayout>
 </template>

--- a/components/scrollTop.vue
+++ b/components/scrollTop.vue
@@ -1,0 +1,55 @@
+<template>
+  <transition name="fade">
+    <button
+      v-if="visible"
+      @click="scrollToTop"
+      class="z-50 p-3 rounded-full text-white text-xl btn-subtle"
+      :class="positionClasses"
+      aria-label="Scroll to top"
+    >
+      ↑
+    </button>
+  </transition>
+</template>
+
+<script setup lang="ts">
+import { ref, onMounted, onUnmounted, computed } from 'vue'
+
+const visible = ref(false)
+
+// Show button after scrolling 300px
+const toggleVisibility = () => {
+  visible.value = window.scrollY > 300
+}
+
+const scrollToTop = () => {
+  window.scrollTo({ top: 0, behavior: 'smooth' })
+}
+
+// Responsive positioning (Tailwind)
+const positionClasses = computed(() => {
+  return [
+    'fixed',
+    'bottom-6',
+    'right-4',
+    'md:right-[30%]',
+  ]
+})
+
+onMounted(() => {
+  window.addEventListener('scroll', toggleVisibility)
+})
+
+onUnmounted(() => {
+  window.removeEventListener('scroll', toggleVisibility)
+})
+</script>
+
+<style scoped>
+.fade-enter-active, .fade-leave-active {
+  transition: opacity 0.3s ease;
+}
+.fade-enter-from, .fade-leave-to {
+  opacity: 0;
+}
+</style>


### PR DESCRIPTION
- adds a button to help scroll back since index main page is long

<img width="1849" height="1071" alt="image" src="https://github.com/user-attachments/assets/426b38bc-0c39-4f97-9ae4-1514773fe165" />

Appears in mobile and desktop, a small button which will be scroll back to top.

Tried to search for native implementation in vuejs or nuxtjs, all I could find is "Scroll to top" which was meant to scroll any new page opened via router to be scroll at top by default

So made a simple implementation as component file