### PR TITLE
use MDC to render markdown content

### DIFF
--- a/components/MaintainerFormRender.vue
+++ b/components/MaintainerFormRender.vue
@@ -13,9 +13,11 @@ defineProps(["maintainer"]);
             {{ item.question }}
           </p>
         </div>
-        <div>
-          <p class="text-secondary-light dark:text-secondary-dark break-words" v-html="item.response"></p>
-        </div>
+
+        <MDC
+          :value="item.response"
+          class="prose dark:prose-invert text-secondary-light dark:text-secondary-dark break-words"
+        />
       </div>
     </template>
   </div>

--- a/components/ProjectDetailSection.vue
+++ b/components/ProjectDetailSection.vue
@@ -8,7 +8,10 @@ defineProps(["project"]);
   <div class="p-8 flex flex-col gap-6 items-start">
     <ProjectLogo :project="project" />
     <h2 class="text-xl font-bold">{{ project.name }}</h2>
-    <p class="text-base sans-text" v-html="project.description"></p>
+    <MDC
+      :value="project.description"
+      class="prose dark:prose-invert text-base sans-text break-words"
+    />
     <Link
       v-if="project.project_link"
       :link="project.project_link"


### PR DESCRIPTION
- helps us avoid ugly html syntax inside json
- easy to parse and let it appear as users intended without much interventions from us