### PR TITLE
Make logo path and button icon `computed()` properties

### DIFF
--- a/components/Header.vue
+++ b/components/Header.vue
@@ -11,7 +11,7 @@ const getLogoPath = computed(() => {
     return "/logo/logo_dark.svg";
   }
 
-  return "/logo/logo_light.svg";
+  return "/logo/logo_dark.svg";
 });
 
 const getButtonIcon = computed(() => {
@@ -21,7 +21,7 @@ const getButtonIcon = computed(() => {
     return DarkModeIcon;
   }
 
-  return LightModeIcon;
+  return DarkModeIcon;
 });
 
 const toggleColorMode = () => {

--- a/components/Header.vue
+++ b/components/Header.vue
@@ -4,7 +4,7 @@ import LightModeIcon from "@/components/icons/LightModeIcon.vue";
 import DarkModeIcon from "@/components/icons/DarkModeIcon.vue";
 const colorMode = useColorMode();
 
-const getLogoPath = () => {
+const getLogoPath = computed(() => {
   if (colorMode.value === "dark") {
     return "/logo/logo_light.svg";
   } else if (colorMode.value === "light") {
@@ -12,9 +12,9 @@ const getLogoPath = () => {
   }
 
   return "/logo/logo_light.svg";
-};
+});
 
-const getButtonIcon = () => {
+const getButtonIcon = computed(() => {
   if (colorMode.value === "dark") {
     return LightModeIcon;
   } else if (colorMode.value === "light") {
@@ -22,7 +22,7 @@ const getButtonIcon = () => {
   }
 
   return LightModeIcon;
-};
+});
 
 const toggleColorMode = () => {
   if (colorMode.value === "dark") {
@@ -45,14 +45,14 @@ const showHeaderLinks = ref(false);
     <nav class="p-9 flex justify-between items-center">
       <div class="flex gap-2 items-center">
         <nuxt-link to="/">
-          <img :src="getLogoPath()" alt="forklore logo" />
+          <img :src="getLogoPath" alt="forklore logo" />
         </nuxt-link>
       </div>
 
       <div class="flex gap-2">
         <header-links class="hidden md:flex"></header-links>
         <button class="btn-solid" @click="toggleColorMode()" :aria-label="themeButtonLabel">
-          <component :is="getButtonIcon()" />
+          <component :is="getButtonIcon" />
         </button>
         <button
           class="btn-subtle block md:!hidden"

--- a/components/HomeHeader.vue
+++ b/components/HomeHeader.vue
@@ -9,7 +9,7 @@ const maintainerCount = computed(() => {
   return maintainers.value?.length || 0;
 });
 
-const getLogoPath = () => {
+const getLogoPath = computed(() => {
   if (colorMode.value === "dark") {
     return "logo/logo_light.svg";
   } else if (colorMode.value === "light") {
@@ -17,13 +17,13 @@ const getLogoPath = () => {
   }
 
   return "logo/logo_light.svg";
-};
+});
 </script>
 
 <template>
   <div class="px-8 pt-40 pb-8 border-custom-b space-y-6">
     <div class="flex items-center gap-4">
-      <img :src="getLogoPath()" alt="forklore logo" class="h-10" />
+      <img :src="getLogoPath" alt="forklore logo" class="h-10" />
     </div>
     <div class="flex flex-col sm:flex-row justify-between">
       <p>

--- a/components/HomeHeader.vue
+++ b/components/HomeHeader.vue
@@ -16,7 +16,7 @@ const getLogoPath = computed(() => {
     return "logo/logo_dark.svg";
   }
 
-  return "logo/logo_light.svg";
+  return "logo/logo_dark.svg";
 });
 </script>
 

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -10,8 +10,8 @@ export default defineNuxtConfig({
     plugins: [tailwindcss()],
   },
   colorMode: {
-    preference: "light",
-    fallback: "dark",
+    preference: "dark",
+    fallback: "light",
     storage: "cookie",
   },
   app: {

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -10,6 +10,8 @@ export default defineNuxtConfig({
     plugins: [tailwindcss()],
   },
   colorMode: {
+    preference: "light",
+    fallback: "dark",
     storage: "cookie",
   },
   app: {


### PR DESCRIPTION
This PR closes #161 and renders `logos/logo_dark.svg` on the initial load of the website in light mode, so that it uses the black-text logo instead of the sage green one (which is intended for dark mode).

| Before | After |
|:-----:|:-----:|
| <img width="5088" height="3032" alt="image" src="https://github.com/user-attachments/assets/7cfe98cc-3972-48c6-a292-3a4f75585d62" /> The website loads with the sage green logo, and the theme switcher button indicates a `.` instead of the moon icon | <img width="5088" height="3032" alt="image" src="https://github.com/user-attachments/assets/590a2202-da8f-4ec2-bc13-14421623599f" /> The website loads with the black-font logo and the theme switcher button indicates the moon icon correctly |

I do not usually work with Vue.js; please verify if this is the correct approach before merging. Thank you!

Noting this here, in case it helps any other maintainers in the future: I ran into https://github.com/nuxt-modules/color-mode/issues/262 for a bit, and the idea is to always load the page with caches disabled; otherwise, `localStorage` interferes with the preference value.