### PR TITLE
Display `⌘` in the search UI on Apple devices

### DIFF
--- a/components/ui/SearchInput.vue
+++ b/components/ui/SearchInput.vue
@@ -11,6 +11,11 @@ const router = useRouter();
 const query = defineModel<string>();
 const sortBy = defineModel<string>("sortBy"); // new
 const inputRef = ref<HTMLInputElement | null>(null);
+const isMac = ref(false);
+
+onMounted(() => {
+  isMac.value = /(Mac|iPhone|iPod|iPad)/i.test(navigator.userAgent);
+});
 
 defineExpose({ focus: () => inputRef.value?.focus?.() });
 
@@ -50,7 +55,7 @@ const goToRandomMaintainer = () => {
         <span
           class="text-xs border rounded px-2 hidden md:inline-block opacity-50"
         >
-          ctrl+k
+          {{ isMac ? '⌘+k' : 'ctrl+k' }}
         </span>
       </div>
 

--- a/components/ui/SearchInput.vue
+++ b/components/ui/SearchInput.vue
@@ -53,7 +53,7 @@ const goToRandomMaintainer = () => {
         />
 
         <span
-          class="text-xs border rounded px-2 hidden md:inline-block opacity-50"
+          class="text-xs border rounded px-2 hidden md:inline-block whitespace-nowrap opacity-80"
         >
           {{ isMac ? '⌘+k' : 'ctrl+k' }}
         </span>


### PR DESCRIPTION
We currently support the `metaKey` for jumping to the search box, but the user interface still displays <kbd>Ctrl</kbd> because this is hard-coded. This update will change it to display the <kbd>⌘</kbd> key on my macOS machine.

I also added the `whitespace-nowrap` class to prevent content from wrapping onto multiple lines on narrower screens. Additionally, I increased the opacity from 50% to 80%, as the previous opacity violated the minimum contrast ratio required for accessibility (80% meets this standard). Please let me know if you'd like me to split this into its own PR.