### PR TITLE
fix: focus search input on '/' key press

### DIFF
--- a/components/MaintainerList.vue
+++ b/components/MaintainerList.vue
@@ -68,6 +68,16 @@ onMounted(() => {
       e.preventDefault();
       searchInputRef.value?.focus();
     }
+    if (
+      e.key === "/" &&
+      !(
+        e.target instanceof HTMLInputElement ||
+        e.target instanceof HTMLTextAreaElement
+      )
+    ) {
+      e.preventDefault();
+      searchInputRef.value?.focus();
+    }
   });
 });
 </script>


### PR DESCRIPTION
This PR adds a keyboard shortcut to focus the search input when the <kbd>/</kbd> key is pressed. This is the shortcut for quick finds in Firefox, and is supported across a wide variety of search engines and webpages with a search area.