### PR TITLE
FIX: Remove OG Image from maintainer page for now

### DIFF
--- a/pages/maintainers/[slug].vue
+++ b/pages/maintainers/[slug].vue
@@ -13,10 +13,6 @@ useHead({
   title: `${maintainer.value?.full_name} | Forklore`,
 });
 
-defineOgImage("Maintainer", {
-  maintainer: maintainer.value,
-});
-
 useSeoMeta({
   title: `${maintainer.value?.full_name} | Forklore`,
   ogTitle: `${maintainer.value?.full_name} | Forklore`,


### PR DESCRIPTION
Remove OG Image from maintainer page for now - all of the maintainer pages are broken at the moment.