### PR TITLE
feat: add self hosted umami for simple site analytics

### DIFF
--- a/site/_includes/base.njk
+++ b/site/_includes/base.njk
@@ -28,6 +28,7 @@
     <link rel="alternate" type="application/rss+xml" href="/planet/rss.xml" title="Planet Forklore Feed">
     <link rel="stylesheet" href="/assets/fonts/fonts.css">
     <link rel="stylesheet" href="/assets/main.css">
+    <script defer src="https://analytics.fossunited.org/script.js" data-website-id="01af9b2b-6b7f-44e6-ab83-377bb415b0f3"></script>
     <script>
       const storedTheme = localStorage.getItem("forklore-theme");
       if (storedTheme === "light") {


### PR DESCRIPTION
- Since its in github pages, we miss site analytics for this and L2L.

We've hosted umami (https://github.com/umami-software/umami) a minimal analytics just for counts purpose on visit.