### PR TITLE
fix: add URL validation in sync-image.py

### DIFF
--- a/sync-image.py
+++ b/sync-image.py
@@ -2,6 +2,8 @@
 import os
 import re
 import json
+import socket
+import ipaddress
 import hashlib
 import requests
 import argparse
@@ -50,7 +52,26 @@ def resolve_url(url):
     return url
 
 
+def is_safe_url(url):
+    """Reject URLs that are not plain http(s) or that resolve to non-public IPs (SSRF guard)."""
+    parsed = urlparse(url)
+    if parsed.scheme not in ("http", "https") or not parsed.hostname:
+        return False
+    try:
+        addrs = socket.getaddrinfo(parsed.hostname, None)
+    except socket.gaierror:
+        return False
+    for *_, sockaddr in addrs:
+        ip = ipaddress.ip_address(sockaddr[0])
+        if not ip.is_global or ip.is_private or ip.is_loopback or ip.is_link_local or ip.is_reserved or ip.is_multicast:
+            return False
+    return True
+
+
 def download(url):
+    if not is_safe_url(url):
+        print(f"[ERROR] {url}: blocked (invalid scheme or non-public address)")
+        return None, None
     try:
         r = requests.get(url, headers=HEADERS, timeout=15)
         r.raise_for_status()


### PR DESCRIPTION
## Summary
Fix high severity security issue in `sync-image.py`.

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | V-002 |
| **Severity** | HIGH |
| **Scanner** | multi_agent_ai |
| **Rule** | `V-002` |
| **File** | `sync-image.py:55` |
| **Assessment** | Likely exploitable |
| **CWE** | CWE-918 |

**Description**: The sync-image.py script fetches images from URLs provided in JSON files without validating the URL scheme or destination. There is no validation to prevent requests to internal IP addresses, cloud metadata endpoints, or private network ranges, allowing Server-Side Request Forgery attacks.

## Evidence

**Exploitation scenario**: Create a maintainer JSON file with a malicious URL in the 'photo' or 'logo' field pointing to internal resources like http://169.254.169.254/latest/meta-data/ (AWS metadata),.

**Scanner confirmation**: multi_agent_ai rule `V-002` flagged this pattern.

**Production code**: This file is in the production codebase, not test-only code.

## Threat Model Context

This is a private Node.js application (not published to npm). Vulnerabilities affect this application's own runtime only.

## Changes
- `sync-image.py`

## Behavior Preservation
The change is scoped to 1 file on the vulnerable path.

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*

<!-- orbis-meta: rule=V-002 scanner=multi_agent_ai -->
